### PR TITLE
Use i18n for command name (Closes #1)

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,8 @@ define(function (require, exports, module) {
     Editor = brackets.getModule("editor/Editor").Editor,
     Dialogs = brackets.getModule("widgets/Dialogs"),
     DefaultDialogs = brackets.getModule("widgets/DefaultDialogs"),
-    DocumentManager = brackets.getModule("document/DocumentManager");
+    DocumentManager = brackets.getModule("document/DocumentManager"),
+    Strings = require("i18n!nls/strings");
 
   var COMMAND_ID = "me.drewbratcher.extract",
     CONTEXTUAL_COMMAND_ID = "me.drewbratcher.extractContextual";
@@ -115,7 +116,7 @@ define(function (require, exports, module) {
   menu.addMenuDivider();
   menu.addMenuItem(COMMAND_ID, command);
 
-  CommandManager.register("Beautify", CONTEXTUAL_COMMAND_ID, extract);
+  CommandManager.register(Strings.COMMAND_NAME, CONTEXTUAL_COMMAND_ID, extract);
   var contextMenu = Menus.getContextMenu(Menus.ContextMenuIds.EDITOR_MENU);
   contextMenu.addMenuItem(CONTEXTUAL_COMMAND_ID);
 

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -1,0 +1,3 @@
+define({
+    "COMMAND_NAME": "Extract"
+});

--- a/nls/strings.js
+++ b/nls/strings.js
@@ -1,0 +1,7 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    module.exports = {
+        root: true
+    };
+});


### PR DESCRIPTION
Hi Drew,

this pull request is fixing #1 by using the [i18n-plugin for require.js](http://requirejs.org/docs/api.html#i18n) instead of a hard-coded string.

Let me know if you would like me to change the other hard-coded strings as well and I’ll update this pull request.
