### PR TITLE
Use localized strings

### DIFF
--- a/dialog.html
+++ b/dialog.html
@@ -1,28 +1,28 @@
 <div class="brackets-extract-dialog modal">
   <div class="modal-header">
-    <h1 class="dialog-title">Extract Refactoring</h1>
+    <h1 class="dialog-title">{{Strings.DIALOG_TITLE}}</h1>
   </div>
   <div class="modal-body" style="margin-left:40px">
     <div class="row" style="text-align:left">
       <div style="display:inline-block;width:200px;text-align:right">
-        New Name:
+        {{Strings.DIALOG_LABEL_NEW_NAME}}:
       </div>
       <div style="display:inline-block;width:200px;text-align:left;margin-left:10px">
-        <input id="newName" type="text" value="extracted">
+        <input id="newName" type="text" value="{{Strings.DIALOG_INPUT_PLACEHOLDER}}">
       </div>
     </div>
     <hr/>
     <div class="row" style="text-align:left">
       <div style="display:inline-block;width:200px;text-align:right;vertical-align:top;">
-        Extract To:
+        {{Strings.DIALOG_LABEL_EXTRACT_TO}}:
         <br/>
       </div>
       <div style="display:inline-block;width:200px;text-align:left">
         <span style='margin:10px'><input id="varOrFunc" type="radio" name="varOrFunc" value="variable" checked/></span>
-        Variable
+        {{Strings.DIALOG_LABEL_VARIABLE}}
         <br/>
         <span style='margin:10px'><input id="varOrFunc" type="radio" name="varOrFunc" value="function" /></span>
-        Function
+        {{Strings.DIALOG_LABEL_FUNCTION}}
       </div>
     </div>
     <!--<hr/>
@@ -41,7 +41,7 @@
   </div>-->
   </div>
   <div class="modal-footer">
-    <a class="dialog-button btn cancel" data-button-id="cancel">Cancel</a>
-    <a class="dialog-button btn primary save" data-button-id="save">Extract</a>
+    <a class="dialog-button btn cancel" data-button-id="cancel">{{BracketsStrings.CANCEL}}</a>
+    <a class="dialog-button btn primary save" data-button-id="save">{{Strings.COMMAND_NAME}}</a>
   </div>
 </div>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
+/*global define, $, brackets, Mustache */
 
 /** {brackets-extract} Extract Refactoring for Brackets
     Provides extract to variable and extract to method functionality for Brackets via an extension.
@@ -15,12 +15,17 @@ define(function (require, exports, module) {
     Dialogs = brackets.getModule("widgets/Dialogs"),
     DefaultDialogs = brackets.getModule("widgets/DefaultDialogs"),
     DocumentManager = brackets.getModule("document/DocumentManager"),
-    Strings = require("i18n!nls/strings");
+    Strings = require("i18n!nls/strings"),
+    BracketsStrings = brackets.getModule("i18n!nls/strings");
 
   var COMMAND_ID = "me.drewbratcher.extract",
     CONTEXTUAL_COMMAND_ID = "me.drewbratcher.extractContextual";
 
   var dialog = require("text!dialog.html");
+  var templateVars = {
+      BracketsStrings: BracketsStrings,
+      Strings: Strings
+  };
 
   function extract() {
     var unformattedText;
@@ -30,7 +35,7 @@ define(function (require, exports, module) {
     if (selectedText.length > 0) {
       unformattedText = selectedText;
     } else {
-      Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERR, "Extract Refactoring Error", "You must highlight some code for extraction.");
+      Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERR, Strings.DIALOG_ERROR_TITLE, Strings.DIALOG_ERROR_NO_SELECTION);
       return;
     }
 
@@ -42,7 +47,7 @@ define(function (require, exports, module) {
     switch (fileType) {
 
     case 'javascript':
-      var openedDialog = Dialogs.showModalDialogUsingTemplate(dialog);
+      var openedDialog = Dialogs.showModalDialogUsingTemplate(Mustache.render(dialog, templateVars));
       var $dom = openedDialog.getElement();
       $dom.find('#newName').select();
       openedDialog.done(function (id) {
@@ -70,7 +75,7 @@ define(function (require, exports, module) {
       });
       break;
     default:
-      Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERR, "Extract Refactoring Error", "Unsupported File: Must be Javascript.");
+      Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERR, Strings.DIALOG_ERROR_TITLE, Strings.DIALOG_ERROR_UNSUPPORTED_FILE);
       return;
     }
   }
@@ -97,7 +102,7 @@ define(function (require, exports, module) {
     });
   }
 
-  CommandManager.register("Extract", COMMAND_ID, extract);
+  CommandManager.register(Strings.COMMAND_NAME, COMMAND_ID, extract);
 
   var menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
 

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -1,3 +1,12 @@
 define({
-    "COMMAND_NAME": "Extract"
+    "COMMAND_NAME":                  "Extract",
+    "DIALOG_ERROR_NO_SELECTION":     "You must highlight some code for extraction.",
+    "DIALOG_ERROR_UNSUPPORTED_FILE": "Unsupported File: Must be Javascript.",
+    "DIALOG_ERROR_TITLE":            "Extract Refactoring Error",
+    "DIALOG_INPUT_PLACEHOLDER":      "extracted",
+    "DIALOG_LABEL_FUNCTION":         "Function",
+    "DIALOG_LABEL_VARIABLE":         "Variable",
+    "DIALOG_LABEL_EXTRACT_TO":       "Extract To",
+    "DIALOG_LABEL_NEW_NAME":         "New Name",
+    "DIALOG_TITLE":                  "Extract Refactoring"
 });


### PR DESCRIPTION
Hi Drew,

this pull request moves all hard-coded strings to `nls/` so they can be localized.
I didn‘t bother about the strings in dialog.html which are commented out, since
they aren‘t in use yet. Let me know if you‘d liked them to be localized as well.

Rebased commits:
- Move all hard-coded UI strings to nls/root
- Move hard-coded UI strings from dialog to nls/
